### PR TITLE
chore: adjust config for AI-generated content

### DIFF
--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,3 @@
+
+# Don't index SpecStory auto-save files, but allow explicit context inclusion via @ references
+.specstory/**

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,11 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+# SpecStory explanation file
+.specstory/.what-is-this.md
+# SpecStory
+.specstory/
+
+.repomix-*
+.cursor/mcp.json

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,8 @@
 ---
 globs:
+  - '**/*.md'
   - '!.cursorrules'
+  - '!.cursor/rules/**'
+  - '!**/node_modules'
+  - '!.specstory/**'
+  - '!.ai/**'


### PR DESCRIPTION
- Introduced .cursorindexingignore to prevent indexing of SpecStory auto-save files.
- Updated .gitignore to exclude SpecStory explanation files and directories.
- Modified .markdownlint-cli2.yaml to ignore SpecStory and AI-related files.