### PR TITLE
chore: change default value for install-playwright input

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -6,8 +6,8 @@ description: Setup pnpm and install dependencies
 inputs:
   install-playwright:
     description: Install Playwright browsers
+    default: 'false'
     required: false
-    default: 'true'
 
 runs:
   steps:


### PR DESCRIPTION
- Updated the default value of the install-playwright input from 'true' to 'false' to prevent unnecessary installations.