### PR TITLE
chore: update image handling in visual tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 *.json linguist-language=JSON-with-Comments
 .cursorrules text linguist-language=Markdown
 llms.txt text linguist-language=Markdown
-*.png filter=lfs diff=lfs merge=lfs -text
+tests/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/visual-tests.yaml
+++ b/.github/workflows/visual-tests.yaml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          lfs: true
           ref: ${{ github.head_ref }}
 
       - name: Setup pnpm
@@ -195,7 +196,6 @@ jobs:
           USER_ID=$(gh api "/users/${GIT_USER_NAME}" --jq .id)
           echo "USER_EMAIL=${USER_ID}+${GIT_USER_NAME}@users.noreply.github.com" >> $GITHUB_OUTPUT
           echo "USER_NAME=${GIT_USER_NAME}" >> $GITHUB_OUTPUT
-          git lfs install
 
       # Commit changes to the branch when triggered from a ref other than main
       - name: Commit changes to HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ coverage
 # Playwright
 test-results/
 playwright-report/
+*.png
+!*-linux.png

--- a/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-chromium-visual-darwin.png
+++ b/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfd8fea5820f6513917216257a1b1dde708df58a066ca935b4997ba5248976f1
-size 55204

--- a/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-firefox-visual-darwin.png
+++ b/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04fcce8e18c72a17c9a466983704acdf5c1d1c369b8e7fa6b852e0bdd97f5541
-size 83671

--- a/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-mobile-chrome-visual-darwin.png
+++ b/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa51195c4bfcf49eed6aa38d25b695106b52f0f563874f694af154fcb40e3721
-size 43758

--- a/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-mobile-safari-visual-darwin.png
+++ b/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3281fc44b46a7bcce6fa71e2a4087e2959448eadb6e65b96501d0cf7d0a70a44
-size 63089

--- a/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-webkit-visual-darwin.png
+++ b/tests/visual/gpt-editor.visual.spec.ts-snapshots/gpt-editor-empty-full-page-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9bef57c2bc5c054a5c15bdcc7e8863044866b04d1037a8e135c48af312c6af98
-size 80658

--- a/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:379ec35c34c87f5d92c3b3882d5dc503db3228500d08136d28d3f6b0317eaf86
-size 2556

--- a/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21df5e7368bf5dd404a9403cd94a45c258452e454a172389c81288deb166b5cc
-size 2990

--- a/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:379ec35c34c87f5d92c3b3882d5dc503db3228500d08136d28d3f6b0317eaf86
-size 2556

--- a/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9af978413ba990889d9bd482c3aa5bef4a57e75e408cb4153db676acb64dcb3f
-size 2924

--- a/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/create-new-gpt-button-png-component-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9af978413ba990889d9bd482c3aa5bef4a57e75e408cb4153db676acb64dcb3f
-size 2924

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:151edb6c59a103030b0af1ccc1d7b5de9032088ec7a374421b9085498dc74f96
-size 98334

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a1e7af7ca947cbf6462a58ddc01ef5e50bf8046c5085b0037a50df21586e44d
-size 131691

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e914235427ae686ba54b6cdd639df571729c077139b7f04ba49a0657aaedeef
-size 112909

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8623e309474cfbefdd04b0c338faa7059beb0a30ca68810aed2d1bf442f2041e
-size 150308

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-dark-theme-full-page-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8e3bdc9e80f9afc51b448d5dba50ee46a9f1e1996779b788371d4c99e999393e
-size 161210

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cb64875b8e08be1681c4d0430df09e2673883caed9389696d9f2f3ec48a2cc2
-size 99244

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0e358862c7bbca8e8971617bb4ab1c67842fdabbac1718159d7013683fa0228
-size 132804

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:410be19d8f7b8585e9ae316d53437c2618cc3e241d6730e7741f141d45d1750d
-size 113517

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ec06e23a73d56244779c79f6dc9f94f77dd8e37c29c4d792ff7a2bbf131b58c
-size 148013

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-empty-state-full-page-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:727488989f4528e8372396698ebf8c5252d0eed47455a45978d35def76a3a60f
-size 159706

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cb64875b8e08be1681c4d0430df09e2673883caed9389696d9f2f3ec48a2cc2
-size 99244

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0e358862c7bbca8e8971617bb4ab1c67842fdabbac1718159d7013683fa0228
-size 132804

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cb64875b8e08be1681c4d0430df09e2673883caed9389696d9f2f3ec48a2cc2
-size 99244

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40d6289c36db99a46a2d8a4f36a3781d80593bd4fa48a1f119889320046aec73
-size 152368

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-desktop-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:727488989f4528e8372396698ebf8c5252d0eed47455a45978d35def76a3a60f
-size 159706

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8adbcc078d71bf4d550c578a238f64ae8b37790542fbc99b6d82db5884a3de0
-size 116376

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bfae1db784583fab348726c1289c6e0af6781b49b7a69483e5b33729c37c8824
-size 163959

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8adbcc078d71bf4d550c578a238f64ae8b37790542fbc99b6d82db5884a3de0
-size 116376

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3938e0ec6f278109db4110bdd86dd602b6b69f49466e24f2eabfa2efb53d3b
-size 176280

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-large-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc26f008c7bfa95c140116b66c7057bd33fa4928732d3faaaefcdc66f2a83484
-size 175878

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:410be19d8f7b8585e9ae316d53437c2618cc3e241d6730e7741f141d45d1750d
-size 113517

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d27e244cecf5f9ca6c431f5f3a77ad2543f34b28d65d11775da89c47fa2ea503
-size 146416

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:410be19d8f7b8585e9ae316d53437c2618cc3e241d6730e7741f141d45d1750d
-size 113517

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ec06e23a73d56244779c79f6dc9f94f77dd8e37c29c4d792ff7a2bbf131b58c
-size 148013

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-mobile-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6f9e2c743f70b67568aa7187495fbff526d4e51eb7ae0218331fc4d7ac2d723
-size 148146

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:406cf416569f5f066978cefe37f16f68174f7d401131cd3ad9dd56e4b9ca5203
-size 109956

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ec6d3bf93a47486cb2e4a186f902cd313eb7f59754163ed6857eaf3cf7c332a
-size 142314

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:406cf416569f5f066978cefe37f16f68174f7d401131cd3ad9dd56e4b9ca5203
-size 109956

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:945f0d808eb5a573f7467eb80970468c401fd81a4c1ebe789e4a7079beb1ffbb
-size 148557

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-responsive-tablet-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23073dde35baf648e7a36b84b32ccca745613df242c7ae082bbab3f66ab5fc08
-size 169944

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6cb64875b8e08be1681c4d0430df09e2673883caed9389696d9f2f3ec48a2cc2
-size 99244

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a0e358862c7bbca8e8971617bb4ab1c67842fdabbac1718159d7013683fa0228
-size 132804

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:410be19d8f7b8585e9ae316d53437c2618cc3e241d6730e7741f141d45d1750d
-size 113517

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0ec06e23a73d56244779c79f6dc9f94f77dd8e37c29c4d792ff7a2bbf131b58c
-size 148013

--- a/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/home-with-gpts-full-page-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:727488989f4528e8372396698ebf8c5252d0eed47455a45978d35def76a3a60f
-size 159706

--- a/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-chromium-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-chromium-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a331cc6d980fdf665647b8886f8336bc2dd52b6c092dce4defeada929aef392
-size 1627

--- a/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-firefox-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-firefox-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c4ac0211fd388fe3ac228ac5bfeb3dafa5be8e57c9812a74043b34aae46463ca
-size 1901

--- a/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-mobile-chrome-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-mobile-chrome-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6a0ecdd348290a97b7d4d8a4596ad1064f036d21d0f0f2dfcf5ae635195dab1
-size 1622

--- a/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-mobile-safari-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-mobile-safari-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:085115aa98ba66efb0073438cba983be1939c3477babc86044a43002e81af4cf
-size 1881

--- a/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-webkit-visual-darwin.png
+++ b/tests/visual/homepage.visual.spec.ts-snapshots/navbar-component-webkit-visual-darwin.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d393264fe4e58c12912f752ed04a131f38030afe2415516d6ead37cc015c2928
-size 1889


### PR DESCRIPTION
- Restrict LFS filter to only apply to images in the tests directory
- Remove obsolete PNG snapshots from visual test cases
- Update .gitignore to exclude all PNG files except for specific ones