### PR TITLE
refactor: migrate GPT name input to HeroUI Input component

### DIFF
--- a/.ai/plan/refactor-form-components-1.md
+++ b/.ai/plan/refactor-form-components-1.md
@@ -57,7 +57,7 @@ Comprehensive migration of form components to implement HeroUI patterns and unif
 
 | Task | Description | Completed | Date |
 | --- | --- | --- | --- |
-| TASK-006 | Replace native input[type="text"] for GPT name with HeroUI Input component in gpt-editor.tsx |  |  |
+| TASK-006 | Replace native input[type="text"] for GPT name with HeroUI Input component in gpt-editor.tsx | ✅ | 2025-08-08 |
 | TASK-007 | Replace native textarea for GPT description with HeroUI Textarea component |  |  |
 | TASK-008 | Replace native textarea for system prompt with HeroUI Textarea component |  |  |
 | TASK-009 | Convert manual error styling (`border-red-300`) to HeroUI `isInvalid` and `errorMessage` props |  |  |

--- a/src/components/gpt-editor.tsx
+++ b/src/components/gpt-editor.tsx
@@ -609,23 +609,26 @@ export function GPTEditor({gptId, onSave}: GPTEditorProps) {
 
             <form onSubmit={handleSubmit} className="space-y-6">
               <div>
-                <label htmlFor="name" className="block text-sm font-medium text-gray-700">
-                  Name
-                </label>
-                <input
+                <Input
                   type="text"
+                  label="Name"
                   name="name"
                   id="name"
                   value={gpt.name}
-                  onChange={handleInputChange}
-                  className={`mt-1 block w-full rounded-md shadow-sm sm:text-sm ${
-                    errors.name
-                      ? 'border-red-300 focus:border-red-500 focus:ring-red-500'
-                      : 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500'
-                  }`}
-                  required
+                  onValueChange={value => {
+                    setGpt(prev => ({
+                      ...prev,
+                      name: value,
+                      updatedAt: new Date(),
+                    }))
+                    if (errors.name) {
+                      clearFieldError('name')
+                    }
+                  }}
+                  isInvalid={!!errors.name}
+                  errorMessage={errors.name}
+                  isRequired
                 />
-                <FormFieldError error={errors.name!} />
               </div>
               <div>
                 <label htmlFor="description" className="block text-sm font-medium text-gray-700">


### PR DESCRIPTION
- Replaced native input[type="text"] for GPT name with HeroUI Input component in gpt-editor.tsx
- Updated error handling to use HeroUI's isInvalid and errorMessage props
- Enhanced accessibility and visual consistency in form interactions

Resolves TASK-006 on #1156.