### PR TITLE
fix(ollama): improve HTTPS→localhost detection and prevent console spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ coverage
 
 .repomix-*
 .cursor/mcp.json
+.mcp.json
 
 !.ai/
 .ai/*

--- a/tests/visual/utils/visual-test-helper.ts
+++ b/tests/visual/utils/visual-test-helper.ts
@@ -239,7 +239,7 @@ export const VisualTestData = {
   /**
    * Create mock GPT configuration with consistent data
    */
-  createMockGPT(overrides: Partial<any> = {}) {
+  createMockGPT(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     return {
       id: 'test-gpt-001',
       name: 'Test GPT Assistant',
@@ -258,8 +258,8 @@ export const VisualTestData = {
           enabled: false,
         },
       },
-      createdAt: new Date('2024-01-01T00:00:00.000Z'),
-      updatedAt: new Date('2024-01-01T00:00:00.000Z'),
+      createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2025-01-01T00:00:00.000Z'),
       version: 1,
       ...overrides,
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import react from '@vitejs/plugin-react-swc'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import {defineConfig} from 'vitest/config'
 
+// CSP via <meta> tag. Note: frame-ancestors is NOT supported in meta tags—
+// browsers ignore it and log a warning. For GitHub Pages (static hosting),
+// HTTP headers aren't configurable, so we omit frame-ancestors here.
+// If clickjacking protection is needed, consider X-Frame-Options via a CDN/proxy.
 const cspPolicy = [
   "default-src 'self'",
   "script-src 'self'",
@@ -12,7 +16,6 @@ const cspPolicy = [
   "img-src 'self' data: blob:",
   "font-src 'self'",
   "object-src 'none'",
-  "frame-ancestors 'none'",
   "form-action 'self'",
   "base-uri 'self'",
 ].join('; ')


### PR DESCRIPTION
- Remove `frame-ancestors` from CSP meta tag (ignored by browsers)
- Add proactive warning banner in Ollama settings for HTTPS→localhost scenario
- Disable auto-polling when mixed-content requests will fail
- Enhance CORS error detection (fetch failed, ERR_FAILED, mixed content)
- Provide actionable error messages with OLLAMA_ORIGINS setup instructions
- Memoize useOllamaStatus return object to prevent unnecessary rerenders
- Add isHttpsToLocalhostScenario() helper for security restriction detection

Fixes console errors on production site (gpt.mrbro.dev) when accessing
Ollama settings, and prevents unexpected provider panel rerenders when
clicking Test button.