### PR TITLE
ci(workflows): optimize and refactor E2E reporting

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -8,8 +8,18 @@ inputs:
     description: Install Playwright browsers
     default: 'false'
     required: false
+  playwright-browsers:
+    description: Playwright browsers to install (space-separated)
+    default: chromium
+    required: false
+
+outputs:
+  playwright-cache-hit:
+    description: Whether Playwright browser cache was hit
+    value: ${{ steps.playwright-cache.outputs.cache-hit }}
 
 runs:
+  using: composite
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -27,9 +37,26 @@ runs:
       run: pnpm install ${{ steps.setup-node.outputs.cache-hit == 'true' && ' --prefer-offline' || '' }}
       shell: 'bash -Eeuo pipefail {0}'
 
-    - if: ${{ inputs.install-playwright == 'true' }}
-      name: Install Playwright browsers
-      run: pnpm exec playwright install --with-deps chromium
+    - name: Get Playwright version
+      if: inputs.install-playwright == 'true'
+      id: playwright-version
+      run: echo "version=$(pnpm list @playwright/test --depth=0 --json | jq -r '.[] | .devDependencies | .["@playwright/test"] | .version')" >> $GITHUB_OUTPUT
       shell: 'bash -Eeuo pipefail {0}'
 
-  using: composite
+    - name: Cache Playwright browsers
+      if: inputs.install-playwright == 'true'
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-${{ inputs.playwright-browsers }}
+
+    - name: Install Playwright browsers
+      if: inputs.install-playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+      run: pnpm exec playwright install --with-deps ${{ inputs.playwright-browsers }}
+      shell: 'bash -Eeuo pipefail {0}'
+
+    - name: Install Playwright system deps (cache hit)
+      if: inputs.install-playwright == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+      run: pnpm exec playwright install-deps ${{ inputs.playwright-browsers }}
+      shell: 'bash -Eeuo pipefail {0}'

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -19,10 +19,10 @@ branches:
       required_status_checks:
         strict: false
         contexts:
-          - Aggregate Coverage
           - Build
           - Deploy
           - E2E Test Coverage
+          - E2E Test Report
           - Generate Accessibility Report
           - Generate Performance Report
           - Lint
@@ -32,7 +32,6 @@ branches:
           - Run Performance Tests
           - Run Tests
           - Run Visual Tests
-          - Unit Test Coverage
 
       enforce_admins: true
       required_pull_request_reviews: null

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -22,43 +22,43 @@ defaults:
     shell: 'bash -Eeuo pipefail {0}'
 
 jobs:
-  unit-coverage:
-    if: github.event.pull_request.draft != true
-    name: Unit Test Coverage
+  prepare:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    name: Prepare
+    outputs:
+      e2e: ${{ steps.filter.outputs.e2e }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup pnpm
-        uses: ./.github/actions/setup-pnpm
-
-      - name: Run unit tests with coverage
-        run: pnpm run test:coverage
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/coverage-final.json,./coverage/lcov.info
-          flags: unit
-          name: unit-tests
-          fail_ci_if_error: false
-          slug: marcusrbrown/gpt
+          ref: ${{ github.head_ref }}
 
-      - name: Upload coverage artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        if: always()
+      - name: Filter changed files
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          name: unit-coverage
-          path: |
-            coverage/
-          retention-days: 30
+          filters: |
+            e2e:
+              - 'src/**'
+              - 'tests/e2e/**'
+              - .github/actions/setup-pnpm/**
+              - .github/workflows/test-coverage.yaml
+              - playwright.config.ts
+              - vite.config.ts
+              - index.html
+              - 'public/**'
+              - package.json
+              - pnpm-lock.yaml
+              - scripts/report-test-results.ts
+              - 'scripts/lib/**'
 
   e2e-coverage:
-    if: github.event.pull_request.draft != true
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.prepare.outputs.e2e == 'true')
     name: E2E Test Coverage
+    needs: [prepare]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -81,61 +81,20 @@ jobs:
             playwright-report/
           retention-days: 30
 
-  aggregate-coverage:
-    name: Aggregate Coverage
-    needs: [unit-coverage, e2e-coverage]
+  report:
+    name: E2E Test Report
+    needs: [e2e-coverage]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && needs.e2e-coverage.result != 'skipped'
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Download unit coverage
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: unit-coverage
-          path: coverage/unit
-
-      - name: Download E2E coverage
+      - name: Download E2E results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: e2e-coverage
-          path: coverage/e2e
-
-      - name: Generate coverage summary
-        id: summary
-        run: |
-          echo "## Test Coverage Summary" > summary.md
-          echo "" >> summary.md
-
-          if [ -f "coverage/unit/coverage-summary.json" ]; then
-            lines=$(jq '.total.lines.pct' coverage/unit/coverage-summary.json 2>/dev/null || echo 0)
-            branches=$(jq '.total.branches.pct' coverage/unit/coverage-summary.json 2>/dev/null || echo 0)
-            functions=$(jq '.total.functions.pct' coverage/unit/coverage-summary.json 2>/dev/null || echo 0)
-            statements=$(jq '.total.statements.pct' coverage/unit/coverage-summary.json 2>/dev/null || echo 0)
-
-            echo "### Unit Test Coverage" >> summary.md
-            echo "- **Lines**: ${lines}%" >> summary.md
-            echo "- **Branches**: ${branches}%" >> summary.md
-            echo "- **Functions**: ${functions}%" >> summary.md
-            echo "- **Statements**: ${statements}%" >> summary.md
-            echo "" >> summary.md
-          fi
-
-          # Count E2E test results
-          if [ -d "coverage/e2e/test-results" ]; then
-            e2e_count=$(find coverage/e2e/test-results -name "*.json" | wc -l)
-            echo "### E2E Test Coverage" >> summary.md
-            echo "- **Test Files**: $e2e_count" >> summary.md
-            echo "" >> summary.md
-          fi
-
-          echo "### Test Types" >> summary.md
-          echo "- ✅ Unit Tests (Vitest + React Testing Library)" >> summary.md
-          echo "- ✅ E2E Tests (Playwright)" >> summary.md
-          echo "- ✅ Visual Regression Tests" >> summary.md
-          echo "- ✅ Accessibility Tests (axe-core)" >> summary.md
-          echo "- ✅ Performance Tests (Lighthouse)" >> summary.md
+          path: .
 
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
@@ -143,19 +102,9 @@ jobs:
       - name: Generate and post report
         if: always()
         run: |
-          # Generate and post coverage report
           node scripts/report-test-results.ts \
-            --type coverage \
-            --results-dir coverage/unit
+            --type e2e \
+            --results-dir test-results
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
-
-      - name: Upload Codecov summary
-        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: aggregated
-          name: aggregated-coverage
-          fail_ci_if_error: false
-          slug: marcusrbrown/gpt

--- a/.github/workflows/test-performance.yaml
+++ b/.github/workflows/test-performance.yaml
@@ -44,7 +44,7 @@ jobs:
             changes:
               - 'src/**'
               - 'tests/performance/**'
-              - .github/workflows/test-performance.yml
+              - .github/workflows/test-performance.yaml
               - playwright-performance.config.ts
               - package.json
               - pnpm-lock.yaml

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
 
   reporter: [
     ['html', {open: 'never'}],

--- a/scripts/lib/formatters/e2e.ts
+++ b/scripts/lib/formatters/e2e.ts
@@ -1,0 +1,66 @@
+import type {E2EResults} from '../parsers/e2e.ts'
+
+export const E2E_COMMENT_IDENTIFIER = '<!-- gpt-e2e-results -->'
+
+export function formatE2EResults(results: E2EResults, runId?: string, repository?: string): string {
+  let body = '## End-to-End Test Report\n\n'
+
+  if (!results.hasResults) {
+    body += '❌ **No E2E test results found**\n\n'
+    body += 'The Playwright results artifact was not available for this run.\n\n'
+    return body
+  }
+
+  body += '### Test Summary\n\n'
+  body += '| Status | Count |\n'
+  body += '|--------|-------|\n'
+  body += `| ✅ Passed | ${results.passed} |\n`
+  body += `| ❌ Failed | ${results.failed} |\n`
+  body += `| ⚠️ Flaky | ${results.flaky} |\n`
+  body += `| ⏭️ Skipped | ${results.skipped} |\n`
+  body += `| **Total** | **${results.total}** |\n\n`
+
+  body += `Duration: ${formatDuration(results.durationMs)}\n\n`
+
+  if (results.failed === 0 && results.flaky === 0) {
+    body += '✅ **All E2E tests passed.**\n\n'
+  } else {
+    body += `❌ **${results.failed} failing test(s), ${results.flaky} flaky test(s)**\n\n`
+
+    if (results.failedTests.length > 0) {
+      body += '### Failing Tests\n\n'
+      for (const test of results.failedTests.slice(0, 10)) {
+        body += `- ${test.title}\n`
+        if (test.error != null) {
+          body += '```\n'
+          body += `${test.error}\n`
+          body += '```\n'
+        }
+      }
+      body += '\n'
+    }
+
+    if (runId != null && repository != null) {
+      body += `View the full workflow run: https://github.com/${repository}/actions/runs/${runId}\n\n`
+    }
+  }
+
+  body += '### Details\n'
+  body += '- Source: Playwright JSON reporter\n'
+  body += '- Artifact includes HTML report and raw test results\n'
+  body += '- Failing and flaky tests are listed above when available\n\n'
+
+  return body
+}
+
+function formatDuration(durationMs: number): string {
+  const roundedSeconds = Math.round(durationMs / 1000)
+  const minutes = Math.floor(roundedSeconds / 60)
+  const seconds = roundedSeconds % 60
+
+  if (minutes === 0) {
+    return `${seconds}s`
+  }
+
+  return `${minutes}m ${seconds}s`
+}

--- a/scripts/lib/formatters/index.ts
+++ b/scripts/lib/formatters/index.ts
@@ -1,4 +1,5 @@
 export {ACCESSIBILITY_COMMENT_IDENTIFIER, formatAccessibilityResults} from './accessibility.ts'
 export {COVERAGE_COMMENT_IDENTIFIER, formatCoverageResults} from './coverage.ts'
+export {E2E_COMMENT_IDENTIFIER, formatE2EResults} from './e2e.ts'
 export {formatPerformanceResults, PERFORMANCE_COMMENT_IDENTIFIER} from './performance.ts'
 export {formatVisualResults, VISUAL_COMMENT_IDENTIFIER} from './visual.ts'

--- a/scripts/lib/parsers/e2e.ts
+++ b/scripts/lib/parsers/e2e.ts
@@ -1,0 +1,133 @@
+import {existsSync, readFileSync} from 'node:fs'
+import {join} from 'node:path'
+import process from 'node:process'
+
+export interface E2ETestStats {
+  duration: number
+  expected: number
+  flaky: number
+  skipped: number
+  unexpected: number
+}
+
+export interface E2EFailure {
+  title: string
+  error?: string
+}
+
+export interface E2EResults {
+  durationMs: number
+  failed: number
+  failedTests: E2EFailure[]
+  flaky: number
+  hasResults: boolean
+  passed: number
+  skipped: number
+  total: number
+}
+
+interface PlaywrightTestAttempt {
+  errors?: {message?: string; value?: string}[]
+}
+
+interface PlaywrightSpec {
+  title: string
+  tests?: {
+    results?: PlaywrightTestAttempt[]
+    status?: 'expected' | 'flaky' | 'skipped' | 'unexpected'
+  }[]
+}
+
+interface PlaywrightSuite {
+  specs?: PlaywrightSpec[]
+  suites?: PlaywrightSuite[]
+  title?: string
+}
+
+interface PlaywrightResults {
+  stats?: Partial<E2ETestStats>
+  suites?: PlaywrightSuite[]
+}
+
+export function parseE2EResults(resultsDir: string): E2EResults {
+  const results: E2EResults = {
+    durationMs: 0,
+    failed: 0,
+    failedTests: [],
+    flaky: 0,
+    hasResults: false,
+    passed: 0,
+    skipped: 0,
+    total: 0,
+  }
+
+  try {
+    const resultsPath = resolveResultsPath(resultsDir)
+    if (resultsPath == null) {
+      return results
+    }
+
+    const content = JSON.parse(readFileSync(resultsPath, 'utf8')) as PlaywrightResults
+    const stats = content.stats
+
+    results.durationMs = stats?.duration ?? 0
+    results.failed = stats?.unexpected ?? 0
+    results.flaky = stats?.flaky ?? 0
+    results.hasResults = true
+    results.passed = stats?.expected ?? 0
+    results.skipped = stats?.skipped ?? 0
+    results.total = results.passed + results.failed + results.flaky + results.skipped
+    results.failedTests = collectFailedTests(content.suites ?? [])
+  } catch (error) {
+    console.error('Failed to parse E2E test results:', error)
+  }
+
+  return results
+}
+
+function resolveResultsPath(resultsDir: string): string | undefined {
+  const candidates = [join(resultsDir, 'results.json'), join(process.cwd(), 'test-results/results.json')]
+  return candidates.find(candidate => existsSync(candidate))
+}
+
+function collectFailedTests(suites: PlaywrightSuite[], titles: string[] = []): E2EFailure[] {
+  const failures: E2EFailure[] = []
+
+  for (const suite of suites) {
+    const nextTitles = suite.title != null && suite.title.length > 0 ? [...titles, suite.title] : titles
+
+    for (const spec of suite.specs ?? []) {
+      const failingTest = spec.tests?.find(test => test.status === 'unexpected' || test.status === 'flaky')
+      if (failingTest != null) {
+        failures.push({
+          title: [...nextTitles, spec.title].join(' > '),
+          error: extractErrorMessage(failingTest.results ?? []),
+        })
+      }
+    }
+
+    failures.push(...collectFailedTests(suite.suites ?? [], nextTitles))
+  }
+
+  return failures
+}
+
+function extractErrorMessage(results: PlaywrightTestAttempt[]): string | undefined {
+  for (const result of results) {
+    for (const error of result.errors ?? []) {
+      if (typeof error.message === 'string' && error.message.length > 0) {
+        return error.message
+      }
+
+      if (typeof error.value === 'string' && error.value.length > 0) {
+        return error.value
+      }
+    }
+  }
+
+  return undefined
+}
+
+export function shouldFailE2E(_results: E2EResults): boolean {
+  return false
+}

--- a/scripts/lib/parsers/index.ts
+++ b/scripts/lib/parsers/index.ts
@@ -4,6 +4,9 @@ export type {AccessibilityResults, AccessibilityViolation} from './accessibility
 export {parseCoverageResults, shouldFailCoverage} from './coverage.ts'
 export type {CoverageResults, CoverageSummary} from './coverage.ts'
 
+export {parseE2EResults, shouldFailE2E} from './e2e.ts'
+export type {E2EFailure, E2EResults, E2ETestStats} from './e2e.ts'
+
 export {parsePerformanceResults, shouldFailPerformance} from './performance.ts'
 export type {LighthouseResult, PerformanceResults} from './performance.ts'
 

--- a/scripts/report-test-results.ts
+++ b/scripts/report-test-results.ts
@@ -3,8 +3,10 @@ import process from 'node:process'
 import {
   ACCESSIBILITY_COMMENT_IDENTIFIER,
   COVERAGE_COMMENT_IDENTIFIER,
+  E2E_COMMENT_IDENTIFIER,
   formatAccessibilityResults,
   formatCoverageResults,
+  formatE2EResults,
   formatPerformanceResults,
   formatVisualResults,
   PERFORMANCE_COMMENT_IDENTIFIER,
@@ -15,15 +17,17 @@ import {JobSummary} from './lib/job-summary.ts'
 import {
   parseAccessibilityResults,
   parseCoverageResults,
+  parseE2EResults,
   parsePerformanceResults,
   parseVisualResults,
   shouldFailAccessibility,
+  shouldFailE2E,
   shouldFailPerformance,
   shouldFailVisual,
 } from './lib/parsers/index.ts'
 
 interface CLIArgs {
-  type: 'performance' | 'accessibility' | 'visual' | 'coverage'
+  type: 'performance' | 'accessibility' | 'visual' | 'coverage' | 'e2e'
   resultsDir: string
 }
 
@@ -35,11 +39,11 @@ function parseArgs(): CLIArgs {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--type' && args[i + 1]) {
       const typeArg = args[i + 1]
-      if (['performance', 'accessibility', 'visual', 'coverage'].includes(typeArg)) {
+      if (['performance', 'accessibility', 'visual', 'coverage', 'e2e'].includes(typeArg)) {
         type = typeArg as CLIArgs['type']
       } else {
         console.error(`Invalid test type: ${typeArg}`)
-        console.error('Valid types: performance, accessibility, visual, coverage')
+        console.error('Valid types: performance, accessibility, visual, coverage, e2e')
         process.exit(1)
       }
       i++
@@ -129,6 +133,17 @@ async function main(): Promise<void> {
       commentIdentifier = COVERAGE_COMMENT_IDENTIFIER
 
       summaryWriter.writeHeading('Test Coverage Report')
+      summaryWriter.write(commentBody)
+      break
+    }
+
+    case 'e2e': {
+      const results = parseE2EResults(resultsDir)
+      commentBody = formatE2EResults(results, runId, repo)
+      commentIdentifier = E2E_COMMENT_IDENTIFIER
+      shouldFail = shouldFailE2E(results)
+
+      summaryWriter.writeHeading('E2E Test Report')
       summaryWriter.write(commentBody)
       break
     }


### PR DESCRIPTION
- replace unit/aggregate coverage flow with changed-file-gated E2E coverage
- add prepare/report jobs and publish E2E Test Report from Playwright results
- add Playwright browser caching and configurable browser list in setup-pnpm action
- add E2E parser/formatter modules and wire new e2e type into report-test-results
- update required status checks to E2E Test Report and remove stale coverage checks
- fix test-performance workflow path-filter filename typo
- increase CI Playwright workers from 1 to 2